### PR TITLE
Fix `dataset` access call for elements that don't have a `dataset`

### DIFF
--- a/packages/snitches/src/createRoot.ts
+++ b/packages/snitches/src/createRoot.ts
@@ -98,7 +98,7 @@ function createSheet(root?: Document): CSSStyleSheet {
   }
 
   // tag the style element so we know it was inserted by snitches
-  if (ownerNode) ownerNode.dataset.snitches = '';
+  if (ownerNode?.dataset) ownerNode.dataset.snitches = '';
 
   // if running in the browser AND the browser supports CSS vars, we can use a single stylesheet and insertRule
   // and fall back in stitches default style insertion logic
@@ -128,7 +128,7 @@ function createSheet(root?: Document): CSSStyleSheet {
         tag = document.createElement('style');
       
         // tag the style element so we know it was inserted by snitches
-        if (tag) tag.dataset.snitches = '';
+        if (tag?.dataset) tag.dataset.snitches = '';
 
         // insert the styles into the tag
         tag.appendChild(document.createTextNode(cssText));

--- a/packages/snitches/src/createRoot.ts
+++ b/packages/snitches/src/createRoot.ts
@@ -187,7 +187,7 @@ function hydrate(groupSheet: CSSStyleSheet, ownerNode?: Document) {
     // all the stylesheets on the page
     .from(Object(ownerNode).styleSheets as StyleSheetList || [])
     // filter to only the set tagged as being server rendered by snitches
-    .filter(sheet => (sheet.ownerNode as HTMLStyleElement)?.dataset.snitchesSsr)
+    .filter(sheet => (sheet.ownerNode as HTMLStyleElement)?.dataset?.snitchesSsr)
 
   // iterate all stylesheets until a hydratable stylesheet is found
   for (const sheet of sheets) {


### PR DESCRIPTION
## What did we change?

This adds an optional chain to the `dataset` property when looping over stylesheet owner elements

## Why are we doing this?

This fixes a crash in IE11, where SVG elements do not have a `dataset` property, causing an exception when we try to access `snitchesSsr` on an undefined object

Below I log `sheet.ownerNode` and `sheet.ownerNode.dataset` - the SVG rows are all `undefined`

<img width="483" alt="Screen Shot 2021-10-29 at 12 02 26 PM" src="https://user-images.githubusercontent.com/1180841/139472829-25201ba8-e658-4112-9498-956fccb6a6b8.png">


