### PR TITLE
fix: change source maps to inline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "snitches-workspace",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.2",
   "scripts": {
     "clean": "workspaces-run -- rm -rf dist -- rm -f tsconfig.tsbuildinfo -- rm -f tsconfig.browser.tsbuildinfo -- rm -rf build -- rm -rf tsconfig.cjs.tsbuildinfo -- rm -rf tsconfig.esm.tsbuildinfo",
     "start": "yarn build && cd example && yarn dev",

--- a/packages/tsconfig.options.json
+++ b/packages/tsconfig.options.json
@@ -15,7 +15,7 @@
     "composite": true,
     "target": "es5",
     "lib": ["dom", "es2016", "es2017.object"],
-    "sourceMap": true,
+    "inlineSourceMap": true,
     "declaration": true,
     "allowJs": true
   },


### PR DESCRIPTION
## What did we change?

Changed source maps to inline.

## Why are we doing this?

An [issue](https://ezcater.slack.com/archives/CBC9DMGP5/p1647278268979789) was raised causing source map parsing warnings during build in a downstream app. Inlining the source maps should fix this (it is how [Recipe](https://github.com/ezcater/recipe/blob/main/package.json#L90) handles source maps).

## Screenshots

Before:
<img width="1534" alt="Screen Shot 2022-03-15 at 9 41 14 AM" src="https://user-images.githubusercontent.com/5418735/158392133-d6bb22a7-145d-4b61-8dc8-5b7b678989b9.png">

After:
<img width="1530" alt="Screen Shot 2022-03-15 at 9 40 34 AM" src="https://user-images.githubusercontent.com/5418735/158392116-6e559a70-e34a-4543-b71c-46d397176dc3.png">
