### PR TITLE
bump snitches version

### DIFF
--- a/packages/snitches/package.json
+++ b/packages/snitches/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezcater/snitches",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Aggregates styles to the head of the application during runtime or inline within components for server-render.",
   "author": "Craig Cavalier",
   "license": "MIT",


### PR DESCRIPTION
## What did we change?

Bumped snitches version to 0.2.9.

## Why are we doing this?

Patch update https://github.com/ezcater/snitches/pull/3.
